### PR TITLE
Ensure gdp, pop, gdppc and urban, returns match mrcommons 0.64.1

### DIFF
--- a/R/calcGDPpcFuture.R
+++ b/R/calcGDPpcFuture.R
@@ -17,19 +17,10 @@ calcGDPpcFuture <- function(GDPpcFuture = "SSPs",
 
   data <- switch(
     GDPpcFuture,
-    "SSPs" = cGDPpcFutureSSPs(),
-    "SDPs" = cGDPpcFutureSDPs(), 
+    "SSPs" = cGDPpcFutureSSPs(useMIData),
+    "SDPs" = cGDPpcFutureSDPs(useMIData), 
     stop("Bad input for calcGDPFuture. Invalid 'GDPFuture' argument.")
   )
-
-  # Fill in data with Missing Islands dataset
-  if (useMIData) {  
-    gdp <- readSource("MissingIslands", subtype = "gdp", convert = FALSE)
-    pop <- readSource("MissingIslands", subtype = "pop", convert = FALSE)
-    countries <- intersect(getRegions(gdp), getRegions(pop))
-    fill <- gdp[countries,,] / pop[countries,,]
-    data <- completeData(data, fill)
-  }
 
   data <- finishingTouches(data, extension2150)
 
@@ -40,17 +31,17 @@ calcGDPpcFuture <- function(GDPpcFuture = "SSPs",
 ######################################################################################
 # Functions
 ######################################################################################
-cGDPpcFutureSSPs <- function() {
+cGDPpcFutureSSPs <- function(useMIData) {
   gdp <- calcOutput("GDPFuture", 
                     GDPFuture = "SSPs", 
-                    useMIData = FALSE, 
+                    useMIData = useMIData, 
                     extension2150 = "none", 
                     aggregate = FALSE)
   gdp <- setNames(gdp, c("gdppc_SSP1", "gdppc_SSP2", "gdppc_SSP3", "gdppc_SSP4", "gdppc_SSP5"))
 
   pop <- calcOutput("PopulationFuture", 
-                    PopulationFuture = "SSPs",
-                    useMIData = FALSE, 
+                    PopulationFuture = "SSPs_old",
+                    useMIData = useMIData, 
                     extension2150 = "none", 
                     aggregate = FALSE)
   pop <- setNames(pop, c("gdppc_SSP1", "gdppc_SSP2", "gdppc_SSP3", "gdppc_SSP4", "gdppc_SSP5"))
@@ -61,8 +52,8 @@ cGDPpcFutureSSPs <- function() {
   data 
 }
 
-cGDPpcFutureSDPs <- function() {
-  data_SSP1 <- cGDPpcFutureSSPs()[,, "gdppc_SSP1"]
+cGDPpcFutureSDPs <- function(useMIData) {
+  data_SSP1 <- cGDPpcFutureSSPs(useMIData)[,, "gdppc_SSP1"]
 
   data <- purrr::map(c("SDP", "SDP_EI", "SDP_RC", "SDP_MC"),
                      ~ setNames(data_SSP1, gsub("SSP1", .x, getNames(data_SSP1)))) %>%

--- a/R/calcGDPpcPast.R
+++ b/R/calcGDPpcPast.R
@@ -16,30 +16,19 @@ calcGDPpcPast <- function(GDPpcPast = "WDI",
 
   # Call appropriate calcGDPPast function.
   data <- switch(GDPpcPast,
-                 "WDI" = cGDPpcPastWDI(),
+                 "WDI" = cGDPpcPastWDI(useMIData),
                  stop("Bad input for calcGDPpcPast. Invalid 'GDPpcPast' argument."))
 
-  if (useMIData) {
-    gdp <- readSource("MissingIslands", subtype = "gdp", convert = FALSE)
-    pop <- readSource("MissingIslands", subtype = "pop", convert = FALSE)
-    countries <- intersect(getRegions(gdp), getRegions(pop))
-    fill <- gdp[countries,,] / pop[countries,,]
-    data <- completeData(data, fill)
-  }
-
-  list(x = data,
-       weight = NULL,
-       unit = unit,
-       description = glue("GDPpc data from {GDPpcPast}."))
+  list(x = data, weight = NULL, unit = unit, description = glue("GDPpc data from {GDPpcPast}."))
 }
 
 
 ######################################################################################
 # Functions
 ######################################################################################
-cGDPpcPastWDI <- function() {
-  gdp <- calcOutput("GDPPast", GDPPast = "WDI", useMIData = FALSE, aggregate = FALSE)
-  pop <- calcOutput("PopulationPast", PopulationPast = "WDI", useMIData = FALSE, aggregate = FALSE)
+cGDPpcPastWDI <- function(useMIData) {
+  gdp <- calcOutput("GDPPast", GDPPast = "WDI", useMIData = useMIData, aggregate = FALSE)
+  pop <- calcOutput("PopulationPast", PopulationPast = "WDI", useMIData = useMIData, aggregate = FALSE)
   years <- intersect(getYears(gdp), getYears(pop))
 
   data <- gdp[, years,] / pop[, years,]

--- a/R/calcPopulation.R
+++ b/R/calcPopulation.R
@@ -76,19 +76,19 @@ internal_calcPopulation <- function(PopulationCalib,
     "past"                 = PopulationPast,
     "future"               = PopulationFuture,
     "transition"           = glue("transition between {PopulationPast} and {PopulationFuture} \\
-                                        with a transition period until 2020"),
+                                  with a transition period until 2020"),
     "past_transition"      = glue("use past data and afterwards transition between \\
-                                        {PopulationPast} and {PopulationFuture} with a transition \\
-                                        period until 2050"),
+                                  {PopulationPast} and {PopulationFuture} with a transition \\
+                                  period until 2050"),
     "past_grFuture"        = glue("use past data from {PopulationPast} and then the growth rates \\
-                                        from {PopulationFuture}."),
+                                  from {PopulationFuture}."),
     "past_grPEAP_grFuture" = glue("use past data from {PopulationPast}, then the growth rates \\
-                                         from the Wolrld Bank's PEAP until 2025, and then the growth \\
-                                         rates from {PopulationFuture}."),
+                                  from the Wolrld Bank's PEAP until 2025, and then the growth \\
+                                  rates from {PopulationFuture}."),
     "Ariadne"              = glue("use past data from {PopulationPast}, then the growth rates \\
-                                        from the Wolrld Bank's PEAP until 2025, and then the growth \\
-                                        rates from {PopulationFuture}. For EUR/ARIADNE countries, \\
-                                        just glue past with future.")
+                                  from the Wolrld Bank's PEAP until 2025, and then the growth \\
+                                  rates from {PopulationFuture}. For EUR/ARIADNE countries, \\
+                                  just glue past with future.")
   )
 
   # Apply finishing touches to combined time-series
@@ -98,8 +98,8 @@ internal_calcPopulation <- function(PopulationCalib,
        weight = NULL,
        unit = "million",
        description = glue("Population data. Datasource for the Past: {PopulationPast}. \\
-                                 Datasource for the Future: {PopulationFuture}. Calibrated \\
-                                 to {datasettype}"))
+                          Datasource for the Future: {PopulationFuture}. Calibrated \\
+                          to {datasettype}"))
 
 }
 
@@ -118,6 +118,8 @@ popHarmonizePast <- function(past, future) {
   } else {
     combined <- tmp
   }
+  combined[combined == Inf] <- 0
+  combined
 }
 
 harmonizePastGrPEAPGrFuture <- function(past, future) {

--- a/R/calcPopulationFuture.R
+++ b/R/calcPopulationFuture.R
@@ -59,7 +59,7 @@ cPopulationFutureSDPs <- function() {
 
   data <- purrr::map(c("SDP", "SDP_EI", "SDP_RC", "SDP_MC"),
                      ~ setNames(data_SSP1, gsub("SSP1", .x, getNames(data_SSP1)))) %>%
-    purrr::reduce(mbind)
+    mbind()
 }
 
 cPopulationFutureSSP2Ariadne <- function() {
@@ -84,10 +84,6 @@ cPopulationFutureSSP2Ariadne <- function() {
   data
 }
 
-
-######################################################################################
-# Legacy
-######################################################################################
 cPopulationFutureSSPsOld <- function() {
   data <- readSource("SSP", subtype = "all")[,,"Population"][,,"IIASA-WiC POP"]
   
@@ -100,6 +96,9 @@ cPopulationFutureSSPsOld <- function() {
   data <- data[,setdiff(getYears(data), c("y2000", "y2005")),]
 }
 
+######################################################################################
+# Legacy
+######################################################################################
 cPopulationFutureSRES <- function() {
   data <- NULL
   for (i in c("sres_a1_pop", "sres_a2_pop", "sres_b1_pop", "sres_b2_pop")) {

--- a/R/calcPopulationPast.R
+++ b/R/calcPopulationPast.R
@@ -58,6 +58,16 @@ cPopulationPastEurostatWDI <- function() {
     dplyr::filter(.data$RegionCode == "EUR") %>% 
     dplyr::pull(.data$CountryCode)
   
+  # Fill in missing ( == 0) eurostat data using wdi growth rates 
+  for (c in EUR_countries) {
+    if (any(data_eurostat[c,,] == 0) && !all(data_eurostat[c,,] == 0)) {
+       data_eurostat[c,,] <- harmonizeFutureGrPast(
+         past = data_wdi[c,,], 
+         future = data_eurostat[c, data_eurostat[c,,] != 0, ]
+        )
+    }
+  }
+
   # Use WDI data for everything but the EUR_countries. Use Eurostat stat for those.
   data <- data_wdi
   data[EUR_countries,,] <- data_eurostat[EUR_countries,,]

--- a/R/calcUrban.R
+++ b/R/calcUrban.R
@@ -26,7 +26,7 @@
 #' 
 calcUrban <- function(UrbanCalib = "past", 
                       UrbanPast = "WDI", 
-                      UrbanFuture = "SSPs",
+                      UrbanFuture = c("SSPs", "SDPs", "SSP2Ariadne"),
                       extension2150 = "constant",
                       FiveYearSteps = TRUE,
                       naming = "indicator_scenario") {

--- a/R/convertJames2019.R
+++ b/R/convertJames2019.R
@@ -29,11 +29,22 @@ convertJames2019 <- function(x, subtype) {
   x1 <- x[c("CHN","HKG","MAC"),getYears(pop),]*pop[c("CHN","HKG","MAC"), getYears(pop),] 
   x1[c("HKG","MAC"),,] <- shr*x1["CHN",,]
   x1["CHN",,] <- x1["CHN",,]-dimSums(x1[c("HKG","MAC"),,], dim=1)
-  
+
   #fill 1950-1959 HKG and MAC with 1960 values, don't subtract from CHINA for these years because no population data to convert to totals, but very small differnece anyways
   x[c("CHN","HKG","MAC"),getYears(x1),] <- x1/pop[c("CHN","HKG","MAC"),,]
   x[c("HKG","MAC"),1950:1959,] <- setYears(x[c("HKG","MAC"),1960,],NULL)
   
+  # South Sudan values are very large, likely inaccurate. In their stead, the Missing island gdp values and WDI pop numbers are used.
+  ssd_gdp <- readSource("MissingIslands", subtype = "gdp", convert = FALSE)["SSD",,]
+  ssd_pop <- readSource("WDI", subtype = "SP.POP.TOTL")["SSD",,] %>% dimReduce()
+  
+  ssd_gdp <- time_interpolate(ssd_gdp, c(1950:2019)) 
+  ssd_pop <- time_interpolate(ssd_pop, c(1950:2019)) 
+  
+  ssd_gdppc <- ssd_gdp/ssd_pop
+  
+  x["SSD",,] <- ssd_gdppc
+
   # Set correct set names
   getSets(x) <- c("iso3c", "year", "variable")
   x

--- a/R/convertWDI.R
+++ b/R/convertWDI.R
@@ -11,15 +11,15 @@
 #' 
 convertWDI <- function(x, subtype){
   
-  if (subtype %in% c("SP_POP_TOTL",
-                     "NY_GDP_MKTP_PP_KD",
-                     "NY_GDP_MKTP_PP_CD",
-                     "NY_GDP_MKTP_CD", 
-                     "NY_GDP_MKTP_CN", 
-                     "NY_GDP_MKTP_KD",
-                     "NY_GDP_MKTP_KN", 
-                     "NV_AGR_TOTL_KD", 
-                     "NV_AGR_TOTL_CD")) {
+  if (subtype %in% c("SP.POP.TOTL",
+                     "NY.GDP.MKTP.PP.KD",
+                     "NY.GDP.MKTP.PP.CD",
+                     "NY.GDP.MKTP.CD", 
+                     "NY.GDP.MKTP.CN", 
+                     "NY.GDP.MKTP.KD",
+                     "NY.GDP.MKTP.KN", 
+                     "NV.AGR.TOTL.KD", 
+                     "NV.AGR.TOTL.CD")) {
     # Change scale of indicators
     x <- x / 1e+6
     # Add Kosovo to Serbia

--- a/R/toolFinishigTouches.R
+++ b/R/toolFinishigTouches.R
@@ -7,6 +7,9 @@ finishingTouches <- function(x, extension2150 = "none", FiveYearSteps = FALSE, n
   # Return only 5-year time steps, if opted for
   if (FiveYearSteps){
     x <- x[, getYears(x, as.integer = TRUE) %% 5 == 0, ]
+    # This operation used to be done using magpiesets::findset("time"), which for some reason
+    # doesn't include 1960. So it's taken out as well.
+    x <- x[, getYears(x, as.integer = TRUE) != 1960, ]
   }
 
   # Clean magpie pbject (necessary?)

--- a/R/toolHarmonizePast.R
+++ b/R/toolHarmonizePast.R
@@ -10,6 +10,7 @@ harmonizePast <- function(past, future) {
   } else {
     combined <- tmp
   }
+
   combined
 }
 

--- a/man/calcUrban.Rd
+++ b/man/calcUrban.Rd
@@ -7,7 +7,7 @@
 calcUrban(
   UrbanCalib = "past",
   UrbanPast = "WDI",
-  UrbanFuture = "SSPs",
+  UrbanFuture = c("SSPs", "SDPs", "SSP2Ariadne"),
   extension2150 = "constant",
   FiveYearSteps = TRUE,
   naming = "indicator_scenario"


### PR DESCRIPTION
calcOutput(GDP) and calcOutput(Population) return the same figures as mrcommons::calcOutput(GDPppp)
and mrcommons::calcOutput(Population), with acceptable differencs after 2100, see below.
GDPpc returns also correctly.

Valid post-2100 differences between default GDP and pop numbers from mrcommons
 (0.64.1) and mrdrivers:

1: For GDPpc after 2100. Bezier extension don't match for any variable,
 since in mrcommons they are not computed, but are simply the result of the
 division of GDP and pop bezier calculations in those years.

2: For GDP and pop after 2100. Bezier extensions don't match for
 SSP2Ariadne and the SDP_XXs, since once again they are not computed in mrcommons
 but are based off of the SSP1 bezier calculations.

3: For pop after 2100, SSPs and SDP. Bezier extensions don't match perfectly
 (small error in the order of 0.001%), since in mrcommons, the bezier extension
 is computed on the level of PopulationFuture, and not at the end of Population,
 where the absolute values in 2095 and 2100 are slightly different. (This is
 my best explanation for the differences.)