### PR TITLE
Fix test-skipping

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1222080'
+ValidationKey: '1241565'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrdrivers: Create GDP and Population Scenarios",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "<p>Create GDP and population scenarios\n    This package constructs the GDP and population scenarios used as drivers in both the REMIND and MAgPIE models.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrdrivers
 Type: Package
 Title: Create GDP and Population Scenarios
-Version: 0.6.4
+Version: 0.6.5
 Authors@R: c(person(given = "Johannes", 
                     family = "Koch", 
                     email = "jokoch@pik-potsdam.de", 
@@ -53,5 +53,5 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
-Date: 2022-04-13
+Date: 2022-04-19
 Config/testthat/edition: 3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create GDP and Population Scenarios
 
-R package **mrdrivers**, version **0.6.4**
+R package **mrdrivers**, version **0.6.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrdrivers)](https://cran.r-project.org/package=mrdrivers)  [![R build status](https://pik-piam.github.io/mrdrivers/workflows/check/badge.svg)](https://pik-piam.github.io/mrdrivers/actions) [![codecov](https://codecov.io/gh/mrdrivers/branch/master/graph/badge.svg)](https://app.codecov.io/gh/mrdrivers) [![r-universe](https://pik-piam.r-universe.dev/badges/mrdrivers)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -89,7 +89,7 @@ In case of questions / problems please contact Johannes Koch <jokoch@pik-potsdam
 
 To cite package **mrdrivers** in publications use:
 
-Koch J, Bodirsky B, Baumstark L, Wang X, Chen D, Leip D, Benke F, Eweron A, Rodrigues R, Giannousakis A, Levesque A, Pehl M, Soergel B, Dietrich J (2022). _mrdrivers: Create GDP and Population Scenarios_. R package version 0.6.4, <URL: https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
+Koch J, Bodirsky B, Baumstark L, Wang X, Chen D, Leip D, Benke F, Eweron A, Rodrigues R, Giannousakis A, Levesque A, Pehl M, Soergel B, Dietrich J (2022). _mrdrivers: Create GDP and Population Scenarios_. R package version 0.6.5, <URL: https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
 
 A BibTeX entry for LaTeX users is
 
@@ -98,7 +98,7 @@ A BibTeX entry for LaTeX users is
   title = {mrdrivers: Create GDP and Population Scenarios},
   author = {Johannes Koch and Benjamin Leon Bodirsky and Lavinia Baumstark and Xiaoxi Wang and David Chen and Deborra Leip and Falk Benke and Araujo Eweron and Renato Rodrigues and Anastasis Giannousakis and Antoine Levesque and Michaja Pehl and Bjoern Soergel and Jan Philipp Dietrich},
   year = {2022},
-  note = {R package version 0.6.4},
+  note = {R package version 0.6.5},
   url = {https://pik-piam.github.io/mrdrivers},
   url = {https://github.com/pik-piam/mrdrivers},
 }

--- a/tests/testthat/_snaps/snaphsots.md
+++ b/tests/testthat/_snaps/snaphsots.md
@@ -793,4 +793,3 @@
         "package": "magclass"
       }
     }
-

--- a/tests/testthat/_snaps/snaphsots.md
+++ b/tests/testthat/_snaps/snaphsots.md
@@ -793,3 +793,4 @@
         "package": "magclass"
       }
     }
+

--- a/tests/testthat/setup-madrat_config.R
+++ b/tests/testthat/setup-madrat_config.R
@@ -1,13 +1,15 @@
 # This file sets specific environment variables and options to make sure devtools::check,
-# which runs in a separate R-session, has the right configuration.
-
-# Madrat config
-oldCfg <- getConfig()
-setConfig(mainfolder =  "/home/johannes/madrat_folder", # nolint
-          cachefolder = "test_mrdrivers",
-          .verbose = FALSE)
+# which runs in a separate R-session, has the right madrat configuration.
 
 # compare_proxy method for magpie objects. Needs to be explicitly assigned to the GlobalEnv for
 # some reason... not required if exported by the package, but that isn't desired for now.
 assign("compare_proxy.magpie", compare_proxy.magpie, envir = .GlobalEnv)
-withr::defer(options(madrat_cfg = oldCfg), teardown_env())
+
+# Madrat config
+madrat_mainfolder <- "/home/johannes/madrat_folder" # nolint
+
+if (dir.exists(madrat_mainfolder)) {
+  oldCfg <- madrat::getConfig()
+  madrat::setConfig(mainfolder = madrat_mainfolder, cachefolder = "test_mrdrivers", .verbose = FALSE)
+  withr::defer(options(madrat_cfg = oldCfg), teardown_env())
+}

--- a/tests/testthat/test-calcOutput_sets.R
+++ b/tests/testthat/test-calcOutput_sets.R
@@ -1,8 +1,8 @@
 skip_on_ci()
 skip_on_covr()
 skip_on_cran()
-skip_if_not(dir.exists(getOption("madrat_cfg")$mainfolder),
-            glue("Skipped, because the madrat mainfolder {getOption('madrat_cfg')$mainfolder} \\
+skip_if_not(dir.exists(madrat_mainfolder),
+            glue("Skipped, because the madrat mainfolder {madrat_mainfolder} \\
                   defined in 'tests/setup_madrat_config.R' could not be found.
                   If you wish to run this test please configure the file appropriately."))
 

--- a/tests/testthat/test-downloads.R
+++ b/tests/testthat/test-downloads.R
@@ -1,9 +1,9 @@
-skip("skip")
+skip(message = "Skipped for time. Comment out line 1 in test-downloads.R to run the test (~5 min).")
 skip_on_ci()
 skip_on_covr()
 skip_on_cran()
-skip_if_not(dir.exists(getOption("madrat_cfg")$mainfolder),
-            glue("Skipped, because the madrat mainfolder {getOption('madrat_cfg')$mainfolder} \\
+skip_if_not(dir.exists(madrat_mainfolder),
+            glue("Skipped, because the madrat mainfolder {madrat_mainfolder} \\
                   defined in 'tests/setup_madrat_config.R' could not be found.
                   If you wish to run this test please configure the file appropriately."))
 

--- a/tests/testthat/test-snaphsots.R
+++ b/tests/testthat/test-snaphsots.R
@@ -1,8 +1,8 @@
 skip_on_ci()
 skip_on_covr()
 skip_on_cran()
-skip_if_not(dir.exists(getOption("madrat_cfg")$mainfolder),
-            glue("Skipped, because the madrat mainfolder {getOption('madrat_cfg')$mainfolder} \\
+skip_if_not(dir.exists(madrat_mainfolder),
+            glue("Skipped, because the madrat mainfolder {madrat_mainfolder} \\
                   defined in 'tests/setup_madrat_config.R' could not be found.
                   If you wish to run this test please configure the file appropriately."))
 


### PR DESCRIPTION
Make sure that most tests are only run if the user actively sets the path to the madrat_mainfolder.