### PR TITLE
Fix warning (or error on newer R versions) and add user-defined scenarios 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2158950'
+ValidationKey: '2341080'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrdrivers: Create GDP and Population Scenarios'
-version: 1.1.1
-date-released: '2023-04-03'
+version: 1.2.0
+date-released: '2023-06-01'
 abstract: Create GDP and population scenarios This package constructs the GDP and
   population scenarios used as drivers in both the REMIND and MAgPIE models.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrdrivers
 Type: Package
 Title: Create GDP and Population Scenarios
-Version: 1.1.1
+Version: 1.2.0
 Authors@R: c(person(given = "Johannes", 
                     family = "Koch", 
                     email = "jokoch@pik-potsdam.de", 
@@ -49,6 +49,6 @@ Suggests:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-Date: 2023-04-03
+Date: 2023-06-01
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/calcGDP.R
+++ b/R/calcGDP.R
@@ -76,7 +76,7 @@ calcGDP <- function(scenario = c("SSPs", "SDPs", "SSP2EU"),
                     supplementary = TRUE,
                     ...)
 
-  if (average2020 && grepl("SSPsOld", scenario)) {
+  if (average2020 && any(grepl("SSPsOld", scenario))) {
     warning("Average 2020 is not compatible with SSPsOld. Setting to FALSE.")
     average2020 <- FALSE
   }

--- a/R/calcGDPHarmonized.R
+++ b/R/calcGDPHarmonized.R
@@ -8,7 +8,8 @@ calcGDPHarmonized <- function(args) {
     "GDPpcWithPop"    = toolMultiplyGDPpcWithPop(args$scenario, args$unit),
     "calibSSP2EU"     = toolGDPHarmonizeSSP2EU(args$past, args$future, args$unit),
     "past_transition" = toolHarmonizePastTransition(args$past$x, args$future$x, yEnd = 2050, aslist = TRUE),
-    stop(glue("Bad input for calcGDPHarmonized. Argument harmonization = '{args$harmonization}' is invalid."))
+    stop(glue("Bad input for calcGDPHarmonized. Argument harmonization = '{args$harmonization}' is invalid. \\
+              Possible values are: 'GDPpcWithPop', 'calibsSSP2EU' or 'past_transition'."))
   )
   list(x = harmonizedData$x, weight = NULL, unit = glue("mil. {args$unit}"), description = harmonizedData$description)
 }

--- a/R/calcGDPpc.R
+++ b/R/calcGDPpc.R
@@ -27,7 +27,7 @@ calcGDPpc <- function(scenario = c("SSPs", "SDPs", "SSP2EU"),
                       supplementary = TRUE,
                       ...)
 
-  if (average2020 && grepl("SSPsOld", scenario)) {
+  if (average2020 && any(grepl("SSPsOld", scenario))) {
     warning("Average 2020 is not compatible with SSPsOld. Setting to FALSE.")
     average2020 <- FALSE
   }
@@ -53,6 +53,7 @@ calcGDPpc <- function(scenario = c("SSPs", "SDPs", "SSP2EU"),
                           aggregate = FALSE,
                           years = 2020)
     gdppc2020 <- gdp2020 / pop2020
+    gdppc2020[is.nan(gdppc2020)] <- 0
     getNames(gdppc2020) <- getNames(gdppc$x)
     gdppc$x[, 2020, ] <- gdppc2020
     gdppc$description <- paste(gdppc$description, "|| 2020 value averaged over 2018-2022 time period.")

--- a/R/toolCheckUserInput.R
+++ b/R/toolCheckUserInput.R
@@ -7,7 +7,8 @@ toolCheckUserInput <- function(driver, args) {
   overrideScen <- if (all(c("pastData", "futureData", "harmonization") %in% names(args))) TRUE else FALSE
 
   # Check population scenario availability for any GDPpc scenario
-  if (!overrideScen && driver == "GDPpc" && ! args$scenario %in% toolGetScenarioDefinition("Population")$scenario) {
+  if (!overrideScen && driver == "GDPpc" &&
+      !all(args$scenario %in% toolGetScenarioDefinition("Population")$scenario)) {
     stop("GDPpc scenarios require equivalent population scenarios to use as weight.")
   }
 
@@ -34,9 +35,10 @@ toolCheckUserInput <- function(driver, args) {
   }
 
   # Check parallel map-reduce compatibility
-  if (any(purrr::map_lgl(args, ~ !is.null(.x) &&
-                                 length(.x) != 1 &&
-                                 length(.x) != max(purrr::map_dbl(args, length))))) {
+  if (any(purrr::map_lgl(args,
+                         ~ !is.null(.x) &&
+                         length(.x) != 1 &&
+                         length(.x) != max(purrr::map_dbl(args, length))))) {
     stop(glue("Arguments to calc{driver} need to be either length 1 or equal to the length of the longest argument."))
   }
 }

--- a/R/toolGetScenarioDefinition.R
+++ b/R/toolGetScenarioDefinition.R
@@ -71,13 +71,17 @@ toolGetScenarioDefinition <- function(driver = NULL, scen = NULL, aslist = FALSE
   # End of scenario-design section
 
   s <- scenarios
+  if (exists("mrdrivers_scenarios")) {
+    message("Also considering user defined scenarios in mrdrivers_scenarios.")
+    s <- dplyr::bind_rows(s, get("mrdrivers_scenarios"))
+  }
 
   if (!is.null(driver)) {
     availableDrivers <- dplyr::pull(scenarios, driver) %>% unique()
     if (!all(driver %in% availableDrivers)) {
       stop(glue::glue("Unknown driver. Available drivers are: {paste(availableDrivers, collapse = ', ')}"))
     }
-    s <- dplyr::filter(scenarios, driver %in% !!driver)
+    s <- dplyr::filter(s, driver %in% !!driver)
   }
 
   if (!is.null(scen)) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create GDP and Population Scenarios
 
-R package **mrdrivers**, version **1.1.1**
+R package **mrdrivers**, version **1.2.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrdrivers)](https://cran.r-project.org/package=mrdrivers)  [![R build status](https://pik-piam.github.io/mrdrivers/workflows/check/badge.svg)](https://pik-piam.github.io/mrdrivers/actions) [![codecov](https://codecov.io/gh/mrdrivers/branch/master/graph/badge.svg)](https://app.codecov.io/gh/mrdrivers) [![r-universe](https://pik-piam.r-universe.dev/badges/mrdrivers)](https://pik-piam.r-universe.dev/builds)
 
@@ -103,7 +103,7 @@ In case of questions / problems please contact Johannes Koch <jokoch@pik-potsdam
 
 To cite package **mrdrivers** in publications use:
 
-Koch J, Soergel B, Leip D, Benke F, Dietrich J (2023). _mrdrivers: Create GDP and Population Scenarios_. R package version 1.1.1, <URL: https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
+Koch J, Soergel B, Leip D, Benke F, Dietrich J (2023). _mrdrivers: Create GDP and Population Scenarios_. R package version 1.2.0, <https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
 
 A BibTeX entry for LaTeX users is
 
@@ -112,7 +112,7 @@ A BibTeX entry for LaTeX users is
   title = {mrdrivers: Create GDP and Population Scenarios},
   author = {Johannes Koch and Bjoern Soergel and Deborra Leip and Falk Benke and Jan Philipp Dietrich},
   year = {2023},
-  note = {R package version 1.1.1},
+  note = {R package version 1.2.0},
   url = {https://pik-piam.github.io/mrdrivers},
   url = {https://github.com/pik-piam/mrdrivers},
 }


### PR DESCRIPTION
Get rid of warning (or error) `'length(x) = 3 > 1' in coercion to 'logical(1)'`.

Allow the user to define custom scenarios by creating a "mrdrivers_scenarios" object. Documentation will be added in an upcoming commit.