### PR TITLE
Update mrdrivers-package.R

### DIFF
--- a/R/mrdrivers-package.R
+++ b/R/mrdrivers-package.R
@@ -7,14 +7,13 @@
 #'
 #' @name mrdrivers-package
 #' @aliases mrdrivers-package mrdrivers
-#' @docType package
 #' @import madrat magclass
 #' @importFrom magrittr %>%
 #' @importFrom rlang .data
 #' @importFrom glue glue
 #' @exportPattern "^((calc(GDP|GDPpc|Population|Labour|Urban)(Past|Future|$))|read|download)"
 #' @keywords internal
-NULL
+"_PACKAGE"
 
 # Suppress R CMD check note
 #' @importFrom lifecycle deprecate_soft


### PR DESCRIPTION
roxygen2 7.3 deprecated `@docType package`, instead `"_PACKAGE" should be the documented object instead of `NULL` now.