### PR TITLE
Shifts start year of SDP_XX GDP scenarios

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,9 +1,11 @@
-ValidationKey: '6022107'
+ValidationKey: '6049664'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
+- ‘qpdf’ is needed for checks on size reduction of PDFs
 AcceptedNotes: ~
 allowLinterWarnings: yes
 AddInReadme: inst/README.md
 enforceVersionUpdate: no
+skipCoverage: no

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6049664'
+ValidationKey: '6069696'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,14 +23,14 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            any::lucode2
-            any::covr
-            any::madrat
-            any::magclass
-            any::citation
-            any::gms
-            any::goxygen
-            any::GDPuc
+            lucode2
+            covr
+            madrat
+            magclass
+            citation
+            gms
+            goxygen
+            GDPuc
           # piam packages also available on CRAN (madrat, magclass, citation,
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
@@ -63,6 +63,6 @@ jobs:
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrdrivers: Create GDP and Population Scenarios'
-version: 3.0.2
+version: 3.0.3
 date-released: '2024-11-05'
 abstract: Create GDP and population scenarios This package constructs the GDP and
   population scenarios used as drivers in both the REMIND and MAgPIE models.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrdrivers: Create GDP and Population Scenarios'
-version: 3.0.1
-date-released: '2024-10-11'
+version: 3.0.2
+date-released: '2024-11-05'
 abstract: Create GDP and population scenarios This package constructs the GDP and
   population scenarios used as drivers in both the REMIND and MAgPIE models.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrdrivers
 Type: Package
 Title: Create GDP and Population Scenarios
-Version: 3.0.1
+Version: 3.0.2
 Authors@R: c(person(given = "Johannes", 
                     family = "Koch", 
                     email = "jokoch@pik-potsdam.de", 
@@ -48,6 +48,6 @@ Suggests:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Date: 2024-10-11
+Date: 2024-11-05
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrdrivers
 Type: Package
 Title: Create GDP and Population Scenarios
-Version: 3.0.2
+Version: 3.0.3
 Authors@R: c(person(given = "Johannes", 
                     family = "Koch", 
                     email = "jokoch@pik-potsdam.de", 

--- a/R/calcGDPpcHarmonized.R
+++ b/R/calcGDPpcHarmonized.R
@@ -267,12 +267,13 @@ computeSHAPEgrowth <- function(shapeGDPScenario, gdppcapSSP1, startFromYear) {
         stop("cannot create SHAPE GDP scenarios: unknown scenario")
       }
 
-      # for service (SDP_MC) and society (SDP_RC) additionally add a smoothing for 2020 and 2025 timesteps
-      # apply only 1/3 (2020-2024) and 2/3 (2025-2029) of the modification
+      # for service (SDP_MC) and society (SDP_RC) additionally add a smoothing for the first two 5-year timesteps
+      # (2025 and 2030 with current default startFromYear = 2025)
+      # apply only 1/3 of the modification for first 5 years, and 2/3 of the modification for another 5 years
       if (shapeGDPScenario %in% c("gdppc_SDP_MC", "gdppc_SDP_RC")) {
-        if (yr >= 2020 && yr < 2025) {
+        if (yr >= startFromYear && yr < startFromYear + 5) {
           modificationFactor[, yr, ] <- 1 / 3. * (modificationFactor[, yr, ] - 1) + 1
-        } else if (yr >= 2025 && yr < 2030) {
+        } else if (yr >= startFromYear + 5 && yr < startFromYear + 10) {
           modificationFactor[, yr, ] <- 2 / 3. * (modificationFactor[, yr, ] - 1) + 1
         }
       }

--- a/R/calcGDPpcHarmonized.R
+++ b/R/calcGDPpcHarmonized.R
@@ -95,7 +95,7 @@ toolGDPpcHarmonizeSDP <- function(unit) {
   combined <- purrr::map(c("gdppc_SDP_EI", "gdppc_SDP_MC", "gdppc_SDP_RC"),
                          computeSHAPEgrowth,
                          gdppcapSSP1 = gdppcapSSP1,
-                         startFromYear = 2020) %>%
+                         startFromYear = 2025) %>%
     mbind() %>%
     mbind(gdppcapSDP)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create GDP and Population Scenarios
 
-R package **mrdrivers**, version **3.0.2**
+R package **mrdrivers**, version **3.0.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrdrivers)](https://cran.r-project.org/package=mrdrivers)  [![R build status](https://pik-piam.github.io/mrdrivers/workflows/check/badge.svg)](https://pik-piam.github.io/mrdrivers/actions) [![codecov](https://codecov.io/gh/mrdrivers/branch/master/graph/badge.svg)](https://app.codecov.io/gh/mrdrivers) [![r-universe](https://pik-piam.r-universe.dev/badges/mrdrivers)](https://pik-piam.r-universe.dev/builds)
 
@@ -103,7 +103,7 @@ In case of questions / problems please contact Johannes Koch <jokoch@pik-potsdam
 
 To cite package **mrdrivers** in publications use:
 
-Koch J, Soergel B, Leip D, Benke F, Dietrich J (2024). _mrdrivers: Create GDP and Population Scenarios_. R package version 3.0.2, <URL: https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
+Koch J, Soergel B, Leip D, Benke F, Dietrich J (2024). _mrdrivers: Create GDP and Population Scenarios_. R package version 3.0.3, <URL: https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
 
 A BibTeX entry for LaTeX users is
 
@@ -112,7 +112,7 @@ A BibTeX entry for LaTeX users is
   title = {mrdrivers: Create GDP and Population Scenarios},
   author = {Johannes Koch and Bjoern Soergel and Deborra Leip and Falk Benke and Jan Philipp Dietrich},
   year = {2024},
-  note = {R package version 3.0.2},
+  note = {R package version 3.0.3},
   url = {https://pik-piam.github.io/mrdrivers},
   url = {https://github.com/pik-piam/mrdrivers},
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create GDP and Population Scenarios
 
-R package **mrdrivers**, version **3.0.1**
+R package **mrdrivers**, version **3.0.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrdrivers)](https://cran.r-project.org/package=mrdrivers)  [![R build status](https://pik-piam.github.io/mrdrivers/workflows/check/badge.svg)](https://pik-piam.github.io/mrdrivers/actions) [![codecov](https://codecov.io/gh/mrdrivers/branch/master/graph/badge.svg)](https://app.codecov.io/gh/mrdrivers) [![r-universe](https://pik-piam.r-universe.dev/badges/mrdrivers)](https://pik-piam.r-universe.dev/builds)
 
@@ -103,7 +103,7 @@ In case of questions / problems please contact Johannes Koch <jokoch@pik-potsdam
 
 To cite package **mrdrivers** in publications use:
 
-Koch J, Soergel B, Leip D, Benke F, Dietrich J (2024). _mrdrivers: Create GDP and Population Scenarios_. R package version 3.0.1, <https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
+Koch J, Soergel B, Leip D, Benke F, Dietrich J (2024). _mrdrivers: Create GDP and Population Scenarios_. R package version 3.0.2, <URL: https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
 
 A BibTeX entry for LaTeX users is
 
@@ -112,7 +112,7 @@ A BibTeX entry for LaTeX users is
   title = {mrdrivers: Create GDP and Population Scenarios},
   author = {Johannes Koch and Bjoern Soergel and Deborra Leip and Falk Benke and Jan Philipp Dietrich},
   year = {2024},
-  note = {R package version 3.0.1},
+  note = {R package version 3.0.2},
   url = {https://pik-piam.github.io/mrdrivers},
   url = {https://github.com/pik-piam/mrdrivers},
 }


### PR DESCRIPTION
SDP_XX GDP scenarios now start deviating from SSP1 GDP in 2025 (previously 2020).

Note: intentional choice to deviate from the SSPs prior to end of IMF near term outlook (currently 2029), to allow some distinction between SDPs and SSPs already by 2030.

@johanneskoch94 the PR adds an additional accepted warning about a qpdf dependency that is unrelated to my PR. 