### PR TITLE
Refactor, improve toolReplaceShortcuts and add deprecation warning for "naming" argument

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '14298690'
+ValidationKey: '14324517'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrdrivers: Create GDP and Population Scenarios'
-version: 7.1.0
-date-released: '2025-02-20'
+version: 7.1.1
+date-released: '2025-02-28'
 abstract: Create GDP and population scenarios This package constructs the GDP and
   population scenarios used as drivers in both the REMIND and MAgPIE models.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrdrivers
 Type: Package
 Title: Create GDP and Population Scenarios
-Version: 7.1.0
+Version: 7.1.1
 Authors@R: c(person(given = "Johannes", 
                     family = "Koch", 
                     email = "jokoch@pik-potsdam.de", 
@@ -44,6 +44,6 @@ Suggests:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Date: 2025-02-20
+Date: 2025-02-28
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/calcGDP.R
+++ b/R/calcGDP.R
@@ -119,7 +119,7 @@ calcGDPpc <- function(scenario, unit = toolGetUnitDollar(inPPP = TRUE), average2
     # before and after.)
     # The dampening is supposed to take place on GDP. So for GDP per capita in 2020 to be consistent with the dampened
     # GDP, it has to calculated from GDP and population. (In other words we cannot just use the same formula as for
-    # GDP, since it would lead to inconsistency at the end.) This is a bit hacky...
+    # GDP, since it would lead to inconsistency at the end.) This is hacky.
     gdp2020 <- calcOutput("GDP",
                           scenario = scenario,
                           extension2150 = "none",

--- a/R/calcGDPFuture.R
+++ b/R/calcGDPFuture.R
@@ -2,12 +2,10 @@
 #' @param futureData A string specifying the sources for future projections.
 #' @order 3
 calcGDPFuture <- function(futureData) {
-  # Check user input
   toolCheckUserInput("GDPFuture", as.list(environment()))
-  # Call calcInternalGDPFuture function the appropriate number of times (map) and combine (reduce)
-  # !! Keep formula syntax for madrat caching to work
-  purrr::pmap(list("futureData" = unlist(strsplit(futureData, "-"))),
-              ~calcOutput("InternalGDPFuture", aggregate = FALSE, supplementary = TRUE, ...)) %>%
+  # Map over components of futureData.
+  purrr::map(unlist(strsplit(futureData, "-")),
+             ~calcOutput("InternalGDPFuture", futureData = .x, aggregate = FALSE, supplementary = TRUE)) %>%
     toolListFillWith()
 }
 
@@ -61,7 +59,7 @@ calcGDPpcFuture <- function(scenario) {
     toolGDPpcFutureFromGDPAndPop(gdpFutureData, popFutureData)
   )
 
-  # The weight does go into the weight of the final scenario. So exact matching with GDPpc not necessary...
+  # The weight does not go into the weight of the final scenario. So exact matching with GDPpc not necessary.
   weight <- calcOutput("PopulationFuture", futureData = popFutureData, aggregate = FALSE)
   getNames(weight) <- getNames(data)
 
@@ -80,7 +78,7 @@ toolGDPpcFutureFromGDPAndPop <- function(gdpFutureData, popFutureData) {
 
 
 
-# Legacy...
+# Legacy.
 toolGDPFutureOtherUnit <- function(data, baseYear, baseYearDef = 2017, convergeBy = 2100) {
   if (baseYear == baseYearDef) {
     return(data)

--- a/R/calcGDPPast.R
+++ b/R/calcGDPPast.R
@@ -3,7 +3,7 @@
 #' @description
 #' Get the past and future scenario building blocks.
 #' If scenario data is required, even if just for a single year, always use the calc call to the final scenario, e.g.
-#' [calcGDP()] or [calcPopulation()], as what is returned by the calc...Past and calc...Future functions may not end up
+#' [calcGDP()] or [calcPopulation()], as what is returned by the calcXPast and calcXFuture functions may not end up
 #' as is in the scenario, depending on the harmonization function.
 #' These functions are only still exported for compatibility with existing code in the PIAM input data pipeline.
 #'
@@ -17,13 +17,11 @@
 #' @keywords internal
 #' @order 1
 calcGDPPast <- function(pastData = toolGetScenarioDefinition("GDPpc", "SSPs")$pastData, extension1960 = "MI-James") {
-  # Check user input
   toolCheckUserInput("GDPPast", as.list(environment()))
 
-  # Call calcInternalGDPPast function the appropriate number of times (map) and combine (reduce)
-  # !! Keep formula syntax for madrat caching to work
-  data <- purrr::pmap(list("pastData" = unlist(strsplit(pastData, "-"))),
-                      ~calcOutput("InternalGDPPast", aggregate = FALSE, supplementary = TRUE, ...)) %>%
+  # Map over components of pastData.
+  data <- purrr::map(unlist(strsplit(pastData, "-")),
+                     ~calcOutput("InternalGDPPast", pastData = .x, aggregate = FALSE, supplementary = TRUE)) %>%
     toolListFillWith()
 
   # If required, project GDP series back to 1960 using growth rates from the extension1960 data set.
@@ -87,7 +85,7 @@ calcGDPpcPast <- function(scenario = "SSPs") {
   data[is.nan(data) | data == Inf] <- 0
   getNames(data) <- paste(gdpPastData, "GDP data", "over", popPastData, "population data")
 
-  # The weight does not go into the weight of the final scenario. So exact matching with GDPpc not necessary...
+  # The weight does not go into the weight of the final scenario. So exact matching with GDPpc not necessary.
   weight <- pop
   getNames(weight) <- getNames(data)
   # Make sure weight and data have the same yearly resolution.

--- a/R/calcPopulationFuture.R
+++ b/R/calcPopulationFuture.R
@@ -1,11 +1,9 @@
 #' @rdname calcGDPPast
 calcPopulationFuture <- function(futureData) {
-  # Check user input
   toolCheckUserInput("PopulationFuture", as.list(environment()))
-  # Call calcInternalPopulationFuture function the appropriate number of times (map) and combine (reduce)
-  # !! Keep formula syntax for madrat caching to work
-  purrr::pmap(list("futureData" = unlist(strsplit(futureData, "-"))),
-              ~calcOutput("InternalPopulationFuture", aggregate = FALSE, supplementary = TRUE, ...)) %>%
+  # Map over components of futureData.
+  purrr::map(unlist(strsplit(futureData, "-")),
+             ~calcOutput("InternalPopulationFuture", futureData = .x, aggregate = FALSE, supplementary = TRUE)) %>%
     toolListFillWith()
 }
 
@@ -37,12 +35,10 @@ toolPopulationFutureSDPs <- function(sdps = c("SDP", "SDP_EI", "SDP_MC", "SDP_RC
 
 #' @rdname calcGDPPast
 calcLabourFuture <- function(futureData) {
-  # Check user input
   toolCheckUserInput("LabourFuture", as.list(environment()))
-  # Call calcInternalPopulationFuture function the appropriate number of times (map) and combine (reduce)
-  # !! Keep formula syntax for madrat caching to work
-  purrr::pmap(list("futureData" = unlist(strsplit(futureData, "-"))),
-              ~calcOutput("InternalLabourFuture", aggregate = FALSE, supplementary = TRUE, ...)) %>%
+  # Map over components of futureData.
+  purrr::map(unlist(strsplit(futureData, "-")),
+             ~calcOutput("InternalLabourFuture", futureData = .x, aggregate = FALSE, supplementary = TRUE)) %>%
     toolListFillWith()
 }
 

--- a/R/calcPopulationFuture.R
+++ b/R/calcPopulationFuture.R
@@ -104,7 +104,7 @@ toolUrbanFutureSSPs <- function(ssps = c("SSP1", "SSP2", "SSP3", "SSP4", "SSP5")
 # The alternative scenario combinations SDP_LS and SDP_GS are not coded explicitly here.
 # They will re-use urban population share settings: SDP_LS = SDP_MC (Green cities), SDP_GS = SDP_EI (Tech cities).
 toolUrbanFutureSDPs <- function() {
-  urbSSPs <- toolUrbanFutureSSPs()
+  urbSSPs <- toolUrbanFutureSSPs(c("SSP1", "SSP2", "SSP3"))
   # SSP1 for the first 3 SDP scenarios
   urbSDPs <- purrr::map(c("SDP", "SDP_EI", "SDP_MC"), ~setNames(urbSSPs[, , "SSP1"], .x)) %>% mbind()
   # SSP2 and SSP3 for SDP_RC

--- a/R/calcPopulationPast.R
+++ b/R/calcPopulationPast.R
@@ -1,11 +1,10 @@
 #' @rdname calcGDPPast
 calcPopulationPast <- function(pastData = toolGetScenarioDefinition("Population", "SSPs")$pastData) {
-  # Check user input
   toolCheckUserInput("PopulationPast", as.list(environment()))
-  # Call calcInternalPopulationPast function the appropriate number of times (map) and combine (reduce)
-  # !! Keep formula syntax for madrat caching to work
-  data <- purrr::pmap(list("pastData" = unlist(strsplit(pastData, "-"))),
-                      ~calcOutput("InternalPopulationPast", aggregate = FALSE, supplementary = TRUE, ...)) %>%
+
+  # Map over components of pastData.
+  data <- purrr::map(unlist(strsplit(pastData, "-")),
+                     ~calcOutput("InternalPopulationPast", pastData = .x, aggregate = FALSE, supplementary = TRUE)) %>%
     toolListFillWith()
 
   # Fill in trailing zeros with closest value
@@ -31,12 +30,10 @@ calcInternalPopulationPast <- function(pastData) {
 
 #' @rdname calcGDPPast
 calcLabourPast <- function(pastData = toolGetScenarioDefinition("Labour", "SSPs")$pastData) {
-  # Check user input
   toolCheckUserInput("LabourPast", as.list(environment()))
-  # Call calcInternalPopulationFuture function the appropriate number of times (map) and combine (reduce)
-  # !! Keep formula syntax for madrat caching to work
-  purrr::pmap(list("pastData" = unlist(strsplit(pastData, "-"))),
-              ~calcOutput("InternalLabourPast", aggregate = FALSE, supplementary = TRUE, ...)) %>%
+  # Map over components of pastData.
+  purrr::map(unlist(strsplit(pastData, "-")),
+             ~calcOutput("InternalLabourPast", pastData = .x, aggregate = FALSE, supplementary = TRUE)) %>%
     toolListFillWith()
 }
 

--- a/R/toolCheckUserInput.R
+++ b/R/toolCheckUserInput.R
@@ -41,7 +41,7 @@ toolCheckUserInput <- function(driver, args) { # nolint: cyclocomp_linter.
     if (args$naming != "scenario") {
       stop(glue("Bad argument to calc{driver}. 'naming' has to be 'scenario', not '{args$naming}'."))
     }
-    message("The 'naming' argument is deprecated. Please drop 'naming = \"scenario\"' from the function call.")
+    warning("The 'naming' argument is deprecated. Please drop 'naming = \"scenario\"' from the function call.")
   }
 
   # Check 'unit' argument. Only constant dollars are allowed.

--- a/R/toolCheckUserInput.R
+++ b/R/toolCheckUserInput.R
@@ -19,7 +19,8 @@ toolCheckUserInput <- function(driver, args) { # nolint: cyclocomp_linter.
   }
 
   # Check 'extension2150' argument
-  if ("extension2150" %in% names(args) && !args$extension2150 %in% c("none", "bezier", "constant")) {
+  if ("extension2150" %in% names(args) &&
+        (!args$extension2150 %in% c("none", "bezier", "constant") || length(args$extension2150) != 1)) {
     stop(glue("Bad argument to calc{driver}. 'extension2150' has to be either 'none', 'bezier' or 'constant', \\
                not '{args$extension2150}'."))
   }
@@ -28,6 +29,11 @@ toolCheckUserInput <- function(driver, args) { # nolint: cyclocomp_linter.
   if ("extension1960" %in% names(args) && !args$extension1960 %in% c("none", "MI-James", "MI", "James")) {
     stop(glue("Bad argument to calc{driver}. 'extension1960' has to be either 'none', 'MI', 'James', or a \\
               combination of both, e.g. 'MI-James', not '{args$extension2150}'."))
+  }
+
+  # Check 'popAsWeight' argument
+  if ("popAsWeight" %in% names(args) && (!is.logical(args$popAsWeight) || length(args$popAsWeight) != 1)) {
+    stop(glue("Bad argument to calc{driver}. 'popAsWeight' has to be either TRUE or FALSE"))
   }
 
   # Check 'naming' argument

--- a/R/toolExtend2150.R
+++ b/R/toolExtend2150.R
@@ -20,7 +20,7 @@ toolExtend2150 <- function(data, extension2150) {
                                seq(2005, 2150, 5),
                                extrapolation_type = "constant",
                                integrate_interpolated_years = TRUE)
-    # Time_interpolate destroys the setNames for some reason...
+    # Time_interpolate destroys the setNames for some reason.
     getSets(data$x) <- helper
     data$description <- glue("{data$description} Extended from 2100 to 2150 using the constant 2100 value.")
   }

--- a/R/toolGetScenarioDefinition.R
+++ b/R/toolGetScenarioDefinition.R
@@ -89,7 +89,7 @@ toolGetScenarioDefinition <- function(driver = NULL, scen = NULL, aslist = FALSE
     "Urban",      "SSP3",            "WDI",                 "SSP3",                   "pastAndGrowth",
     "Urban",      "SSP4",            "WDI",                 "SSP4",                   "pastAndGrowth",
     "Urban",      "SSP5",            "WDI",                 "SSP5",                   "pastAndGrowth",
-    "Urban",      "SDPs",            "WDI",                 "SDPs",                   "pastAndGrowth",
+    "Urban",      "SDPs",            "WDI",                 "SDPs",                   "pastAndGrowth"
   )
 
   shortcuts <- list("SSPs" = c("SSP1", "SSP2", "SSP3", "SSP4", "SSP5"),
@@ -152,7 +152,13 @@ toolGetScenarioDefinition <- function(driver = NULL, scen = NULL, aslist = FALSE
 #' toolReplaceShortcuts("SSPs")
 #'
 toolReplaceShortcuts <- function(scenario) {
+  if (!is.character(scenario)) {
+    stop("Scenario argument must be a string or vector of strings.")
+  }
   shortcuts <- toolGetScenarioDefinition(getGroupShortcuts = TRUE)
-  c(scenario[! scenario %in% names(shortcuts)],
-    unlist(shortcuts[names(shortcuts) %in% scenario], use.names = FALSE))
+  x <- as.list(scenario)
+  for (s in seq_along(x)) {
+    if (x[[s]] %in% names(shortcuts)) x[[s]] <-  unlist(shortcuts[names(shortcuts) %in% scenario], use.names = FALSE)
+  }
+  unlist(x)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create GDP and Population Scenarios
 
-R package **mrdrivers**, version **7.1.0**
+R package **mrdrivers**, version **7.1.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrdrivers)](https://cran.r-project.org/package=mrdrivers) [![R build status](https://pik-piam.github.io/mrdrivers/workflows/check/badge.svg)](https://pik-piam.github.io/mrdrivers/actions) [![codecov](https://codecov.io/gh/mrdrivers/branch/master/graph/badge.svg)](https://app.codecov.io/gh/mrdrivers) [![r-universe](https://pik-piam.r-universe.dev/badges/mrdrivers)](https://pik-piam.r-universe.dev/builds)
 
@@ -103,7 +103,7 @@ In case of questions / problems please contact Johannes Koch <jokoch@pik-potsdam
 
 To cite package **mrdrivers** in publications use:
 
-Koch J, Soergel B, Leip D, Benke F, Dietrich J (2025). "mrdrivers: Create GDP and Population Scenarios." Version: 7.1.0, <https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
+Koch J, Soergel B, Leip D, Benke F, Dietrich J (2025). "mrdrivers: Create GDP and Population Scenarios." Version: 7.1.1, <https://pik-piam.github.io/mrdrivershttps://github.com/pik-piam/mrdrivers>.
 
 A BibTeX entry for LaTeX users is
 
@@ -111,10 +111,10 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrdrivers: Create GDP and Population Scenarios},
   author = {Johannes Koch and Bjoern Soergel and Deborra Leip and Falk Benke and Jan Philipp Dietrich},
-  date = {2025-02-20},
+  date = {2025-02-28},
   year = {2025},
   url = {https://pik-piam.github.io/mrdrivers},
   url = {https://github.com/pik-piam/mrdrivers},
-  note = {Version: 7.1.0},
+  note = {Version: 7.1.1},
 }
 ```

--- a/man/calcGDPPast.Rd
+++ b/man/calcGDPPast.Rd
@@ -51,7 +51,7 @@ calcUrbanPast(pastData = toolGetScenarioDefinition("Urban", "SSPs")$pastData)
 \description{
 Get the past and future scenario building blocks.
 If scenario data is required, even if just for a single year, always use the calc call to the final scenario, e.g.
-\code{\link[=calcGDP]{calcGDP()}} or \code{\link[=calcPopulation]{calcPopulation()}}, as what is returned by the calc...Past and calc...Future functions may not end up
+\code{\link[=calcGDP]{calcGDP()}} or \code{\link[=calcPopulation]{calcPopulation()}}, as what is returned by the calcXPast and calcXFuture functions may not end up
 as is in the scenario, depending on the harmonization function.
 These functions are only still exported for compatibility with existing code in the PIAM input data pipeline.
 


### PR DESCRIPTION
- Stop reordering of scenarios in toolReplaceShortcuts
- Bump version
- Simplify some calcOutput functions by dropping use of ... .
- Turn note into warning for deprecated "naming" argument
